### PR TITLE
Add python 3.7, remove 3.5 from test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ matrix:
   include:
   - os: linux
     env:
-    - PYTHON_VERSION=3.5
-    - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-    python: 3.5
-  - os: linux
-    env:
     - PYTHON_VERSION=3.6
     - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     python: 3.6
+  - os: linux
+    env:
+    - PYTHON_VERSION=3.7
+    - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    python: 3.7
 before_install:
 - openssl aes-256-cbc -K $encrypted_a0a62c26415d_key -iv $encrypted_a0a62c26415d_iv
   -in pliers/tests/credentials/google.json.enc -out pliers/tests/credentials/google.json -d || true
@@ -35,7 +35,7 @@ install:
 - sudo apt-get install libboost-python-dev
 - pip install --upgrade --ignore-installed setuptools
 - pip install -r requirements.txt --upgrade
-- pip install -r optional-dependencies.txt --upgrade 
+- pip install -r optional-dependencies.txt --upgrade
 - pip install --upgrade coveralls pytest-cov
 
 before_script:


### PR DESCRIPTION
- 3.5 and 3.6 are no longer supported for Miniconda